### PR TITLE
fix: CSS変数の競合と未定義参照を修正

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
     href.startsWith('/') ? `${basePath}${href}` : href;
 
   return (
-    <header className="fixed w-full bg-white/90 backdrop-blur-sm z-50 border-b">
+    <header className="fixed w-full bg-background/90 backdrop-blur-sm z-50 border-b">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           <Button variant="ghost" className="font-bold text-xl p-0" asChild>
@@ -63,7 +63,7 @@ export function Header() {
 
       {/* Mobile Menu */}
       {isMenuOpen && (
-        <div className="md:hidden absolute w-full bg-white border-b">
+        <div className="md:hidden absolute w-full bg-background border-b">
           <nav className="container mx-auto px-4 py-4">
             <ul className="space-y-4">
               {[

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -49,7 +49,7 @@ export function Contact() {
   };
 
   return (
-    <section id="contact" className="py-20 bg-gray-50">
+    <section id="contact" className="py-20 bg-muted">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
           お問い合わせ

--- a/src/components/sections/Founder.tsx
+++ b/src/components/sections/Founder.tsx
@@ -7,7 +7,7 @@ export function Founder() {
   const avatarSrc = `${basePath}/images/shuya_higuchi_bali.jpg`;
 
   return (
-    <section id="about" className="py-20 bg-white">
+    <section id="about" className="py-20 bg-background">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
           創業者
@@ -26,7 +26,7 @@ export function Founder() {
                 <p className="text-primary font-medium mb-4">
                   Eフロンピア合同会社代表
                 </p>
-                <p className="text-gray-600 leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed">
                   フルスタック開発とビジネス経験を活かし、北海道から新しい価値を創造することを目指しています。技術とビジネスの架け橋として、お客様の成長をサポートいたします。
                 </p>
               </div>

--- a/src/components/sections/Origin.tsx
+++ b/src/components/sections/Origin.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 
 export function Origin() {
   return (
-    <section className="py-20 bg-white">
+    <section className="py-20 bg-background">
       <div className="container mx-auto px-4">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -16,7 +16,7 @@ export function Origin() {
 
           <Card className="max-w-3xl mx-auto">
             <CardContent className="p-8">
-              <p className="text-gray-600 leading-relaxed text-lg">
+              <p className="text-muted-foreground leading-relaxed text-lg">
                 Eフロンピアという社名には3つの想いが込められています。「いいフロンティア」と「仲間（peer）」の融合、そして北海道の古称「蝦夷（Ezo）」の「E」。また、11月26日の創業日は「いい風呂の日」にちなんでおり、心地よい価値を生み出したいという願いが込められています。
               </p>
             </CardContent>

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -21,7 +21,7 @@ const services = [
 
 export function Services() {
   return (
-    <section id="services" className="py-20 bg-white">
+    <section id="services" className="py-20 bg-background">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
           サービス内容
@@ -39,7 +39,7 @@ export function Services() {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-gray-600">
+                <p className="text-muted-foreground">
                   {description}
                 </p>
               </CardContent>

--- a/src/components/sections/Timeline.tsx
+++ b/src/components/sections/Timeline.tsx
@@ -59,7 +59,7 @@ const timelineEntries = [
 
 export function Timeline() {
   return (
-    <section className="py-20 bg-gray-50">
+    <section className="py-20 bg-muted">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl md:text-4xl font-bold text-center mb-12">
           創業までの道のり
@@ -91,7 +91,7 @@ export function Timeline() {
                     <h3 className="text-xl font-bold text-primary mb-2">
                       {title}
                     </h3>
-                    <p className="text-gray-600">{description}</p>
+                    <p className="text-muted-foreground">{description}</p>
                   </CardContent>
                 </Card>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,15 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 200 47.4% 40.2%;
     --radius: 0.75rem;
+
+    /* Blog / Markdown用カラー */
+    --code-bg: #f1f1f1;
+    --pre-bg: #f5f5f5;
+    --blockquote-border: #dddddd;
+    --table-header-bg: #f6f8fa;
+    --table-border: #dddddd;
+    --link-color: #0070f3;
+    --link-hover-color: #0051a2;
   }
 
   html {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { SWRConfig } from "swr";
 import "../index.css";
+import "../styles/globals.css";
 import "../styles/markdown.css";
 import { fetcher } from "@/lib/fetcher";
 import type { AppProps } from "next/app";

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -23,15 +23,15 @@ export default function PostPage({ post }: Props) {
                 <nav className="mb-8">
                     <Link
                         href="/blog"
-                        className="text-blue-600 hover:text-blue-800 transition-colors flex items-center gap-2"
+                        className="text-primary hover:text-primary/80 transition-colors flex items-center gap-2"
                     >
                         ← ブログ一覧に戻る
                     </Link>
                 </nav>
-                <article className="bg-white rounded-lg shadow-md p-8">
+                <article className="bg-card rounded-lg shadow-md p-8">
                     <header className="mb-8">
-                        <h1 className="text-4xl font-bold mb-4 text-gray-900">{post.title}</h1>
-                        <div className="flex items-center gap-4 text-sm text-gray-600 border-b border-gray-200 pb-4">
+                        <h1 className="text-4xl font-bold mb-4 text-foreground">{post.title}</h1>
+                        <div className="flex items-center gap-4 text-sm text-muted-foreground border-b border-border pb-4">
                             <time dateTime={post.date}>
                                 更新日：
                                 {new Date(post.date).toLocaleDateString('ja-JP', {

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -22,17 +22,17 @@ export default function BlogIndex({ posts }: Props) {
                 <h1 className="text-4xl font-bold text-center mb-12">ブログ記事一覧</h1>
                 <div className="grid gap-8">
                     {posts.map((post) => (
-                        <article key={post.slug} className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+                        <article key={post.slug} className="bg-card rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
                             <div className="post-header">
                                 <h2 className="text-2xl font-bold mb-3">
                                     <Link
                                         href={`/blog/${post.slug}`}
-                                        className="text-gray-900 hover:text-blue-600 transition-colors"
+                                        className="text-foreground hover:text-primary transition-colors"
                                     >
                                         {post.title}
                                     </Link>
                                 </h2>
-                                <div className="flex items-center gap-4 text-sm text-gray-600">
+                                <div className="flex items-center gap-4 text-sm text-muted-foreground">
                                     <time dateTime={post.date}>
                                         更新日：
                                         {new Date(post.date).toLocaleDateString('ja-JP')}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,76 +1,13 @@
-@import "tailwindcss";
-
-:root {
-    --background: #ffffff;
-    --foreground: #171717;
-    --secondary: #666666;
-    --border: #eeeeee;
-    --link: #0070f3;
-    --link-hover: #0051a2;
-    --code-bg: #f1f1f1;
-    --pre-bg: #f5f5f5;
-    --blockquote-border: #dddddd;
-    --table-header-bg: #f6f8fa;
-    --table-border: #dddddd;
-    --avatar-border: #dddddd;
-
-    /* 見出しカラー */
-    --h1-color: #e74c3c;
-    --h2-color: #3498db;
-    --h3-color: #2ecc71;
-    --h4-color: #f39c12;
-    --h5-color: #9b59b6;
-    --h6-color: #34495e;
-}
-
-@theme inline {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --font-sans: var(--font-geist-sans);
-    --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #0a0a0a;
-        --foreground: #ededed;
-        --secondary: #a0a0a0;
-        --border: #333333;
-        --link: #58a6ff;
-        --link-hover: #79c0ff;
-        --code-bg: #2d3748;
-        --pre-bg: #1a202c;
-        --blockquote-border: #4a5568;
-        --table-header-bg: #2d3748;
-        --table-border: #4a5568;
-        --avatar-border: #4a5568;
-
-        /* ダークモード用見出しカラー */
-        --h1-color: #ff6b6b;
-        --h2-color: #4ecdc4;
-        --h3-color: #45b7d1;
-        --h4-color: #f9ca24;
-        --h5-color: #a55eea;
-        --h6-color: #95afc0;
-    }
-}
-
-body {
-    background: var(--background);
-    color: var(--foreground);
-    font-family: Arial, Helvetica, sans-serif;
-}
-
-.container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 2rem;
+/* ナビゲーション用のリストのみスタイルを無効化 */
+.post-list {
+    list-style: none;
+    padding: 0;
 }
 
 .post-item {
     margin-bottom: 2rem;
     padding: 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
 }
 
 .post-item h2 {
@@ -78,22 +15,16 @@ body {
 }
 
 .post-item h2 a {
-    color: var(--link);
+    color: var(--link-color);
     text-decoration: none;
 }
 
 .post-item h2 a:hover {
-    color: var(--link-hover);
+    color: var(--link-hover-color);
 }
 
 .post-item small {
-    color: var(--secondary);
-}
-
-/* ナビゲーション用のリストのみスタイルを無効化 */
-.post-list {
-    list-style: none;
-    padding: 0;
+    color: hsl(var(--muted-foreground));
 }
 
 article {
@@ -104,7 +35,7 @@ article {
 .post-meta {
     margin-bottom: 2rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid hsl(var(--border));
 }
 
 .author-info {
@@ -118,12 +49,12 @@ article {
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    border: 2px solid var(--avatar-border);
+    border: 2px solid hsl(var(--border));
 }
 
 .author-name {
     font-size: 0.9rem;
-    color: var(--secondary);
+    color: hsl(var(--muted-foreground));
     font-weight: 500;
 }
 
@@ -152,12 +83,12 @@ article {
     width: 24px;
     height: 24px;
     border-radius: 50%;
-    border: 1px solid var(--avatar-border);
+    border: 1px solid hsl(var(--border));
 }
 
 .post-author-name {
     font-size: 0.8rem;
-    color: var(--secondary);
+    color: hsl(var(--muted-foreground));
     font-weight: 500;
 }
 
@@ -166,70 +97,5 @@ article {
         flex-direction: column;
         align-items: flex-start;
         gap: 0.5rem;
-    }
-}
-
-/* ヘッダーのスタイル */
-.site-header {
-    background: var(--background);
-    border-bottom: 1px solid var(--border);
-    padding: 1rem 0;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    backdrop-filter: blur(10px);
-}
-
-.header-container {
-    max-width: 800px;
-    margin: 0 auto;
-    padding: 0 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.site-title {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: bold;
-}
-
-.site-title a {
-    color: var(--foreground);
-    text-decoration: none;
-}
-
-.site-title a:hover {
-    color: var(--link);
-}
-
-.main-nav {
-    display: flex;
-    gap: 1rem;
-}
-
-.nav-link {
-    color: var(--secondary);
-    text-decoration: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    transition: all 0.2s ease;
-}
-
-.nav-link:hover {
-    color: var(--link);
-    background-color: var(--code-bg);
-}
-
-@media (max-width: 768px) {
-    .header-container {
-        padding: 0 1rem;
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    .site-title {
-        font-size: 1.2rem;
     }
 }

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,7 +1,7 @@
 /* Markdownスタイル */
 .markdown-body {
     line-height: 1.6 !important;
-    color: var(--foreground) !important;
+    color: hsl(var(--foreground)) !important;
     font-size: 16px !important;
 }
 
@@ -14,18 +14,18 @@
     margin-top: 1.5em !important;
     margin-bottom: 0.5em !important;
     font-weight: bold !important;
-    color: var(--foreground) !important;
+    color: hsl(var(--foreground)) !important;
 }
 
 .markdown-body h1 {
     font-size: 2rem !important;
-    border-bottom: 2px solid var(--border) !important;
+    border-bottom: 2px solid hsl(var(--border)) !important;
     padding-bottom: 0.3em !important;
 }
 
 .markdown-body h2 {
     font-size: 1.6rem !important;
-    border-bottom: 1px solid var(--border) !important;
+    border-bottom: 1px solid hsl(var(--border)) !important;
     padding-bottom: 0.3em !important;
 }
 
@@ -107,7 +107,7 @@
     border-left: 4px solid var(--blockquote-border) !important;
     margin: 1em 0 !important;
     padding-left: 1em !important;
-    color: var(--secondary) !important;
+    color: hsl(var(--secondary)) !important;
     font-style: italic !important;
 }
 
@@ -115,12 +115,12 @@
     border-collapse: collapse !important;
     width: 100% !important;
     margin: 1em 0 !important;
-    border: 2px solid #000000 !important;
+    border: 2px solid var(--table-border) !important;
 }
 
 .markdown-body th,
 .markdown-body td {
-    border: 1px solid #000000 !important;
+    border: 1px solid var(--table-border) !important;
     padding: 0.75em !important;
     text-align: left !important;
 }
@@ -140,13 +140,13 @@
 
 /* リンクのスタイル */
 .markdown-body a {
-    color: #0066cc !important;
+    color: var(--link-color) !important;
     text-decoration: underline !important;
     font-weight: 500 !important;
 }
 
 .markdown-body a:hover {
-    color: #004499 !important;
+    color: var(--link-hover-color) !important;
     text-decoration: none !important;
 }
 


### PR DESCRIPTION
## Summary
- `markdown.css`のCSS変数参照が壊れていた問題を修正（Tailwind v3のHSL形式変数を`hsl()`で囲まずに直接使用していたため、無効なCSSになっていた）
- `globals.css`からTailwind v4構文（`@import "tailwindcss"`, `@theme inline`）と競合するCSS変数定義を削除
- `index.css`にブログ/マークダウン用CSS変数（`--code-bg`, `--table-border`等）を追加
- 各コンポーネントのハードコード色（`bg-white`, `text-gray-600`等）をテーマ対応クラス（`bg-background`, `text-muted-foreground`等）に統一

## Test plan
- [ ] トップページの各セクション（Hero, Origin, Services, Timeline, Founder, Contact）の表示確認
- [ ] ブログ一覧ページの表示確認
- [ ] ブログ記事ページのマークダウン（見出し、コードブロック、テーブル、引用、リンク）の表示確認
- [ ] `npm run build` が成功すること

https://claude.ai/code/session_01Nbmf1wTnwAHa9tYMJNiWzs